### PR TITLE
Telegram Bot

### DIFF
--- a/Trader/API/Telegram/__init__.py
+++ b/Trader/API/Telegram/__init__.py
@@ -1,0 +1,1 @@
+from telegram_bot import TelegramBot

--- a/Trader/API/Telegram/telegram_bot.py
+++ b/Trader/API/Telegram/telegram_bot.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+from django.apps import AppConfig
+import logging
+import telegram.bot
+from telegram.ext import Updater, CommandHandler, MessageHandler, Filters
+
+
+class TelegramBotConfig(AppConfig):
+    name = "API.Telegram"
+    verbose_name = "TelegramBot"
+
+    def ready(self):
+        bot = TelegramBot()
+        bot.start_bot()
+
+
+class TelegramBot():
+    def start_bot(self):
+        token = settings.TOKEN
+        updater = Updater(token=token)
+        # bot = telegram.Bot(token=TOKEN)
+        dispatcher = updater.dispatcher
+        logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+        def help(bot, update):
+            bot.send_message(chat_id=update.message.chat_id, text="To register to notifications please use the "
+                                                                  "following command: /register [Email]")
+
+        def register(bot, update):
+            email = str.strip(update.message.text[10])
+            register_text = "To register to notifications please use the " \
+                            "following command: /register [Email]"
+            bot.send_message(chat_id=update.message.chat_id, text=register_text)
+
+        def caps(bot, update, args):
+            if args:
+                text_caps = ' '.join(args).upper()
+            else:
+                text_caps = 'NO MESSAGE PROVIDED'
+            bot.send_message(chat_id=update.message.chat_id, text=text_caps)
+
+        def unknown(bot, update):
+            bot.send_message(chat_id=update.message.chat_id, text="Sorry, I didn't understand that command.")
+
+        help_handler = CommandHandler('start', help)
+        register_handler = MessageHandler(Filters.text, register)
+        caps_handler = CommandHandler('caps', caps, pass_args=True)
+        register_help_handler = CommandHandler('register', register)
+        unknown_handler = MessageHandler(Filters.command, unknown)
+        dispatcher.add_handler(help_handler)
+        dispatcher.add_handler(register_handler)
+        dispatcher.add_handler(register_help_handler)
+        dispatcher.add_handler(caps_handler)
+        dispatcher.add_handler(unknown_handler)
+        updater.start_polling()
+        updater.idle()
+
+    def stop_bot(self):
+        token = settings.TOKEN
+        updater = Updater(token=token)
+        updater.stop()

--- a/Trader/Trader/settings.py
+++ b/Trader/Trader/settings.py
@@ -27,6 +27,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Telegram Token
+TOKEN = "518166944:AAFzE8juLrHHp8nbujgBxjfSFlJ9TC1Xvkk"
 
 # Application definition
 
@@ -38,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'API',
+    'API.Telegram.telegram_bot.TelegramBotConfig'
 ]
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ djangorestframework>=3.4.3
 pytz
 tox
 flake8
+python-telegram-bot
+telegram


### PR DESCRIPTION
Se agregó la funcionalidad del Bot de telegram que por el momento solo muestra informacion y recibe una instruccion: /register [email] el cual se usara para validar que el usuario exista y que se pueda obtener su chat_id